### PR TITLE
support user name override in role crd

### DIFF
--- a/apis/postgresql/v1alpha1/role_types.go
+++ b/apis/postgresql/v1alpha1/role_types.go
@@ -74,6 +74,11 @@ type RoleSpec struct {
 	// +kubebuilder:validation:Required
 	PasswordSecretRef common.SecretKeySelector `json:"passwordSecretRef,omitempty"`
 
+	// UserNameOverride allows specifying a custom username for the PostgreSQL role.
+	// When set, this takes precedence over the role name from the CRD metadata.
+	// +optional
+	UserNameOverride *string `json:"userNameOverride,omitempty"`
+
 	// ConnectionLimit to be applied to the role.
 	// +kubebuilder:validation:Min=-1
 	// +optional

--- a/apis/postgresql/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/postgresql/v1alpha1/zz_generated.deepcopy.go
@@ -402,6 +402,11 @@ func (in *RoleSpec) DeepCopyInto(out *RoleSpec) {
 	*out = *in
 	out.ConnectSecretRef = in.ConnectSecretRef
 	out.PasswordSecretRef = in.PasswordSecretRef
+	if in.UserNameOverride != nil {
+		in, out := &in.UserNameOverride, &out.UserNameOverride
+		*out = new(string)
+		**out = **in
+	}
 	if in.ConnectionLimit != nil {
 		in, out := &in.ConnectionLimit, &out.ConnectionLimit
 		*out = new(int32)

--- a/chart/postgresql-operator/templates/role-crd.yaml
+++ b/chart/postgresql-operator/templates/role-crd.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -54,8 +55,8 @@ spec:
             description: RoleSpec defines the desired state of Role
             properties:
               connectSecretRef:
-                description: ConnectSecretRef references the secret that contains database
-                  details () used to create this role.
+                description: ConnectSecretRef references the secret that contains
+                  database details () used to create this role.
                 properties:
                   name:
                     description: Name of the resource.
@@ -73,8 +74,8 @@ spec:
                 format: int32
                 type: integer
               passwordSecretRef:
-                description: PasswordSecretRef references the secret that contains the
-                  password used for this role.
+                description: PasswordSecretRef references the secret that contains
+                  the password used for this role.
                 properties:
                   key:
                     description: The key to select.
@@ -100,13 +101,13 @@ spec:
                     type: boolean
                   createDb:
                     default: false
-                    description: CreateDb grants CREATEDB when true, allowing the role
-                      to create databases.
+                    description: CreateDb grants CREATEDB when true, allowing the
+                      role to create databases.
                     type: boolean
                   createRole:
                     default: false
-                    description: CreateRole grants CREATEROLE when true, allowing this
-                      role to create other roles.
+                    description: CreateRole grants CREATEROLE when true, allowing
+                      this role to create other roles.
                     type: boolean
                   inherit:
                     default: false
@@ -128,6 +129,11 @@ spec:
                     description: SuperUser grants SUPERUSER privilege when true.
                     type: boolean
                 type: object
+              userNameOverride:
+                description: UserNameOverride allows specifying a custom username
+                  for the PostgreSQL role. When set, this takes precedence over the
+                  role name from the CRD metadata.
+                type: string
             type: object
           status:
             description: RoleStatus defines the observed state of Role
@@ -137,8 +143,8 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    \n type FooStatus struct{ // Represents the observations of a foo's
-                    current state. // Known .status.conditions.type are: \"Available\",
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
                     \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
                     // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
@@ -152,8 +158,8 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating details
-                        about the transition. This may be an empty string.
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
@@ -167,11 +173,11 @@ spec:
                       type: integer
                     reason:
                       description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers of
-                        specific condition types may define expected values and meanings
-                        for this field, and whether the values are considered a guaranteed
-                        API. The value should be a CamelCase string. This field may
-                        not be empty.
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$

--- a/config/crd/bases/postgresql.facets.cloud_roles.yaml
+++ b/config/crd/bases/postgresql.facets.cloud_roles.yaml
@@ -128,6 +128,11 @@ spec:
                     description: SuperUser grants SUPERUSER privilege when true.
                     type: boolean
                 type: object
+              userNameOverride:
+                description: UserNameOverride allows specifying a custom username
+                  for the PostgreSQL role. When set, this takes precedence over the
+                  role name from the CRD metadata.
+                type: string
             type: object
           status:
             description: RoleStatus defines the observed state of Role

--- a/config/samples/postgresql_v1alpha1_role_with_username_override.yaml
+++ b/config/samples/postgresql_v1alpha1_role_with_username_override.yaml
@@ -1,0 +1,28 @@
+apiVersion: postgresql.facets.cloud/v1alpha1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: role
+    app.kubernetes.io/instance: role-example-with-override
+    app.kubernetes.io/part-of: postgresql-operator
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: postgresql-operator
+  name: role-example-with-override
+spec:
+  connectSecretRef:
+    name: db-conn
+    namespace: default
+  passwordSecretRef:
+    namespace: default
+    name: db-conn
+    key: role_password
+  userNameOverride: "_"
+  connectionLimit: 100
+  privileges:
+    bypassRls: false
+    createDb: false
+    createRole: false
+    inherit: false
+    login: true
+    replication: false
+    superUser: false

--- a/config/samples/postgresql_v1alpha1_role_with_username_override.yaml
+++ b/config/samples/postgresql_v1alpha1_role_with_username_override.yaml
@@ -16,7 +16,7 @@ spec:
     namespace: default
     name: db-conn
     key: role_password
-  userNameOverride: "_"
+  userNameOverride: "test_user"
   connectionLimit: 100
   privileges:
     bypassRls: false

--- a/controllers/postgresql/grantstatement_controller.go
+++ b/controllers/postgresql/grantstatement_controller.go
@@ -205,7 +205,7 @@ func (r *GrantStatementReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 
 		// Revoke all privileges from the role before granting new privileges
-		err, message = r.revokeAllPrivileges(grantStatement, prevDatabase, prevRoleRef, secret)
+		err, message = r.revokeAllPrivileges(ctx, grantStatement, prevDatabase, prevRoleRef, secret)
 		if err != nil {
 			message := fmt.Sprintf("Failed to revoke all privileges for GrantStatement %s/%s: %s", grantStatement.Namespace, grantStatement.Name, message)
 			r.appendGrantStatementStatusCondition(ctx, grantStatement, common.FAIL, metav1.ConditionFalse, common.FAIL, fmt.Sprintf("%s: %s", message, err.Error()))
@@ -257,7 +257,7 @@ func (r *GrantStatementReconciler) finalizeGrantStatement(ctx context.Context, g
 		logger.Error(err, message)
 		return fmt.Errorf("failed to retrieve secret from current state for GrantStatement %s/%s: %s", grantStatement.Namespace, grantStatement.Name, err.Error())
 	}
-	err, message = r.revokeAllPrivileges(grantStatement, database, roleRef, secret)
+	err, message = r.revokeAllPrivileges(ctx, grantStatement, database, roleRef, secret)
 	if err != nil {
 		r.appendGrantStatementStatusCondition(ctx, grantStatement, common.FAIL, metav1.ConditionFalse, common.FAIL, err.Error())
 		logger.Error(err, message)
@@ -268,7 +268,7 @@ func (r *GrantStatementReconciler) finalizeGrantStatement(ctx context.Context, g
 	return nil
 }
 
-func (r *GrantStatementReconciler) revokeAllPrivileges(grantStatement *postgresqlv1alpha1.GrantStatement, database string, roleRef common.ResourceReference, secret *corev1.Secret) (error, string) {
+func (r *GrantStatementReconciler) revokeAllPrivileges(ctx context.Context, grantStatement *postgresqlv1alpha1.GrantStatement, database string, roleRef common.ResourceReference, secret *corev1.Secret) (error, string) {
 	var message string
 	db, err := common.ConnectToPostgres(secret, database)
 	if err != nil {
@@ -298,7 +298,20 @@ func (r *GrantStatementReconciler) revokeAllPrivileges(grantStatement *postgresq
 		schemas = append(schemas, schema)
 	}
 
-	role := fmt.Sprintf("\"%s\"", roleRef.Name)
+	// Get the Role object to access UserNameOverride
+	roleObj := &postgresqlv1alpha1.Role{}
+	err = r.Get(ctx, types.NamespacedName{
+		Namespace: roleRef.Namespace,
+		Name:      roleRef.Name,
+	}, roleObj)
+	if err != nil {
+		message = fmt.Sprintf("Failed to get role resource %s/%s for GrantStatement %s", roleRef.Namespace, roleRef.Name, grantStatement.Name)
+		logger.Error(err, message)
+		return err, message
+	}
+
+	effectiveRoleName := getEffectiveRoleName(roleObj)
+	role := fmt.Sprintf("\"%s\"", effectiveRoleName)
 	rootUser := string(secret.Data[common.ResourceCredentialsSecretUserKey])
 
 	// For each schema, execute each SQL command to revoke all privileges as a separate transaction

--- a/controllers/postgresql/role_controller.go
+++ b/controllers/postgresql/role_controller.go
@@ -79,6 +79,15 @@ type RoleReconciler struct {
 	Scheme *runtime.Scheme
 }
 
+// getEffectiveRoleName returns the PostgreSQL role name to use.
+// If UserNameOverride is set, it takes precedence over the CRD name.
+func getEffectiveRoleName(role *postgresql.Role) string {
+	if role.Spec.UserNameOverride != nil && *role.Spec.UserNameOverride != "" {
+		return *role.Spec.UserNameOverride
+	}
+	return role.Name
+}
+
 //+kubebuilder:rbac:groups=postgresql.facets.cloud,resources=roles,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=postgresql.facets.cloud,resources=roles/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=postgresql.facets.cloud,resources=roles/finalizers,verbs=update
@@ -179,7 +188,7 @@ func (r *RoleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	defaultDatabase := string(connectionSecret.Data[common.ResourceCredentialsSecretDatabaseKey])
 	roleDB, err = common.ConnectToPostgres(connectionSecret, defaultDatabase)
 	if err != nil {
-		reason := fmt.Sprintf("Failed connecting to database for role `%s`", role.Name)
+		reason := fmt.Sprintf("Failed connecting to database for role `%s`", getEffectiveRoleName(role))
 		roleLogger.Error(err, reason)
 		r.appendRoleStatusCondition(ctx, role, common.FAIL, metav1.ConditionFalse, common.CONNECTIONFAILED, err.Error())
 	}
@@ -325,31 +334,31 @@ func (r *RoleReconciler) findObjectsForSecret(secret client.Object) []reconcile.
 
 func (r *RoleReconciler) CreateRole(ctx context.Context, role *postgresql.Role, rolePassword string) (string, metav1.ConditionStatus, string, string) {
 	privileges := strings.Join(PrivilegesToClauses(role.Spec.Privileges), " ")
-	createRoleQuery := fmt.Sprintf("CREATE ROLE \"%s\" WITH %s PASSWORD '%s' CONNECTION LIMIT %d", role.Name, privileges, rolePassword, *role.Spec.ConnectionLimit)
+	createRoleQuery := fmt.Sprintf("CREATE ROLE \"%s\" WITH %s PASSWORD '%s' CONNECTION LIMIT %d", getEffectiveRoleName(role), privileges, rolePassword, *role.Spec.ConnectionLimit)
 	_, err := roleDB.Exec(createRoleQuery)
 	if err != nil {
-		if strings.Contains(err.Error(), fmt.Sprintf("pq: role \"%s\" already exists", role.Name)) {
-			roleLogger.Error(err, fmt.Sprintf("Role `%s` created outside of database operator.", role.Name))
+		if strings.Contains(err.Error(), fmt.Sprintf("pq: role \"%s\" already exists", getEffectiveRoleName(role))) {
+			roleLogger.Error(err, fmt.Sprintf("Role `%s` created outside of database operator.", getEffectiveRoleName(role)))
 			return common.FAIL, metav1.ConditionFalse, ROLECREATEFAILED, errRoleCreatedOutside
 		} else {
-			roleLogger.Error(err, fmt.Sprintf("Failed to create role `%s`, Check if the secret `%s/%s` has valid database connection details", role.Name, role.Spec.ConnectSecretRef.Namespace, role.Spec.ConnectSecretRef.Name))
+			roleLogger.Error(err, fmt.Sprintf("Failed to create role `%s`, Check if the secret `%s/%s` has valid database connection details", getEffectiveRoleName(role), role.Spec.ConnectSecretRef.Namespace, role.Spec.ConnectSecretRef.Name))
 			return common.FAIL, metav1.ConditionFalse, ROLECREATEFAILED, fmt.Sprintf("%s, Check if the secret `%s/%s` has valid database connection details", err.Error(), role.Spec.ConnectSecretRef.Namespace, role.Spec.ConnectSecretRef.Name)
 		}
 	}
 
-	roleLogger.Info(fmt.Sprintf("Role `%s` got created successfully", role.Name))
+	roleLogger.Info(fmt.Sprintf("Role `%s` got created successfully", getEffectiveRoleName(role)))
 	return common.CREATE, metav1.ConditionTrue, ROLECREATED, "Role created successfully"
 }
 
 func (r *RoleReconciler) DeletRole(ctx context.Context, role *v1alpha1.Role) (string, metav1.ConditionStatus, string, string, error) {
-	deleteRoleQuery := fmt.Sprintf("DROP ROLE IF EXISTS \"%s\"", role.Name)
+	deleteRoleQuery := fmt.Sprintf("DROP ROLE IF EXISTS \"%s\"", getEffectiveRoleName(role))
 	_, err := roleDB.Exec(deleteRoleQuery)
 	if err != nil {
-		roleLogger.Error(err, fmt.Sprintf("Failed to delete role `%s`", role.Name))
+		roleLogger.Error(err, fmt.Sprintf("Failed to delete role `%s`", getEffectiveRoleName(role)))
 		return common.FAIL, metav1.ConditionFalse, ROLEDELETEFAILED, err.Error(), err
 	}
 
-	roleLogger.Info(fmt.Sprintf("Role `%s` got deleted successfully", role.Name))
+	roleLogger.Info(fmt.Sprintf("Role `%s` got deleted successfully", getEffectiveRoleName(role)))
 	return common.DELETE, metav1.ConditionTrue, ROLEDELETED, "Role deleted successfully", err
 }
 
@@ -376,23 +385,23 @@ func (r *RoleReconciler) SyncRole(ctx context.Context, role *postgresql.Role, ro
 		}
 	}
 
-	alterRoleQuery := fmt.Sprintf("ALTER ROLE \"%s\" WITH %s PASSWORD '%s' CONNECTION LIMIT %d", role.Name, strings.Join(privileges, " "), rolePassword, *role.Spec.ConnectionLimit)
+	alterRoleQuery := fmt.Sprintf("ALTER ROLE \"%s\" WITH %s PASSWORD '%s' CONNECTION LIMIT %d", getEffectiveRoleName(role), strings.Join(privileges, " "), rolePassword, *role.Spec.ConnectionLimit)
 	_, err := roleDB.Exec(alterRoleQuery)
 	if err != nil {
-		if strings.Contains(err.Error(), fmt.Sprintf("pq: role \"%s\" does not exist", role.Name)) {
-			roleLogger.Error(err, fmt.Sprintf("Failed to sync role `%s`. Role deleted outside of database operator ", role.Name))
+		if strings.Contains(err.Error(), fmt.Sprintf("pq: role \"%s\" does not exist", getEffectiveRoleName(role))) {
+			roleLogger.Error(err, fmt.Sprintf("Failed to sync role `%s`. Role deleted outside of database operator ", getEffectiveRoleName(role)))
 			return common.SYNC, metav1.ConditionFalse, ROLESYNCFAILED, errRoleDeletedOutside
 		} else {
-			roleLogger.Error(err, fmt.Sprintf("Failed to sync role `%s`", role.Name))
+			roleLogger.Error(err, fmt.Sprintf("Failed to sync role `%s`", getEffectiveRoleName(role)))
 			return common.SYNC, metav1.ConditionFalse, ROLESYNCFAILED, err.Error()
 		}
 	}
 
 	if isPasswordSync {
-		roleLogger.Info(fmt.Sprintf("Role `%s` password got synced successfully", role.Name))
+		roleLogger.Info(fmt.Sprintf("Role `%s` password got synced successfully", getEffectiveRoleName(role)))
 		return common.SYNC, metav1.ConditionTrue, ROLEPASSWORDSYNCED, "Role password synced successfully"
 	}
-	roleLogger.Info(fmt.Sprintf("Role `%s` got synced successfully", role.Name))
+	roleLogger.Info(fmt.Sprintf("Role `%s` got synced successfully", getEffectiveRoleName(role)))
 	return common.SYNC, metav1.ConditionTrue, ROLESYNCED, "Role synced successfully"
 }
 
@@ -411,7 +420,7 @@ func (r *RoleReconciler) ObserveRoleState(ctx context.Context, role *postgresql.
 
 	err := roleDB.QueryRow(
 		observeRoleStateQuery,
-		role.Name,
+		getEffectiveRoleName(role),
 		&role.Spec.Privileges.SuperUser,
 		&role.Spec.Privileges.Inherit,
 		&role.Spec.Privileges.CreateRole,
@@ -422,7 +431,7 @@ func (r *RoleReconciler) ObserveRoleState(ctx context.Context, role *postgresql.
 		&role.Spec.Privileges.BypassRls,
 	).Scan(&isRoleStateChanged)
 	if err != nil {
-		roleLogger.Error(err, fmt.Sprintf("Failed to get role `%s` when observing ", role.Name))
+		roleLogger.Error(err, fmt.Sprintf("Failed to get role `%s` when observing ", getEffectiveRoleName(role)))
 		r.appendRoleStatusCondition(ctx, role, common.FAIL, metav1.ConditionFalse, ROLEGETFAILED, err.Error())
 	}
 	return isRoleStateChanged


### PR DESCRIPTION
This pr adds support to mention username override in role crd. why? requirement to use `_` as username from customer and old behaviour creates role with role.Name from crd, since Kubernetes restricts the naming of crd, this change is required which allows user to create crd with different name and user with different name.

## Testing

Testing yamls 

- db-conn secret
```yaml
apiVersion: v1
kind: Secret
metadata:
  name: db-conn
  namespace: default
type: Opaque
stringData:
  endpoint: "test-postgres-service"
  port: "5432"
  database: "testdb"
  username: "postgres"
  password: "password"
  sslmode: "disable"
  role_password: "mynewrolepassword"
```

- test-roles.yaml
```yaml
apiVersion: postgresql.facets.cloud/v1alpha1
kind: Role
metadata:
  name: test-role-with-override
  namespace: default
spec:
  connectSecretRef:
    name: db-conn
    namespace: default
  passwordSecretRef:
    namespace: default
    name: db-conn
    key: role_password
  userNameOverride: "custom_user_name"
  connectionLimit: 50
  privileges:
    login: true
    createDb: true
    inherit: false
    superUser: false
    createRole: false
    replication: false
    bypassRls: false
---
apiVersion: postgresql.facets.cloud/v1alpha1
kind: Role
metadata:
  name: test-role-without-override
  namespace: default
spec:
  connectSecretRef:
    name: db-conn
    namespace: default
  passwordSecretRef:
    namespace: default
    name: db-conn
    key: role_password
  connectionLimit: 50
  privileges:
    login: true
    createDb: false
    inherit: false
    superUser: false
    createRole: false
    replication: false
    bypassRls: false
```

- test-grantstatements.yaml
```yaml
apiVersion: postgresql.facets.cloud/v1alpha1
kind: GrantStatement
metadata:
  name: grant-to-custom-user
  namespace: default
spec:
  roleRef:
    name: test-role-with-override
    namespace: default
  database: "testdb"
  statements:
  - 'GRANT CONNECT ON DATABASE testdb TO "custom_user_name";'
  - 'GRANT USAGE ON SCHEMA public TO "custom_user_name";'
  - 'GRANT SELECT, INSERT, UPDATE ON ALL TABLES IN SCHEMA public TO "custom_user_name";'
---
apiVersion: postgresql.facets.cloud/v1alpha1
kind: GrantStatement
metadata:
  name: grant-to-normal-role
  namespace: default
spec:
  roleRef:
    name: test-role-without-override
    namespace: default
  database: "testdb"
  statements:
  - 'GRANT CONNECT ON DATABASE testdb TO "test-role-without-override";'
  - 'GRANT USAGE ON SCHEMA public TO "test-role-without-override";'
  - 'GRANT SELECT ON ALL TABLES IN SCHEMA public TO "test-role-without-override";'
```

Creation and Deletion:

- commands
```bash
~/repos/work/postgresql-operator main* ❯ clear                                                        1m 8s 15:22:11
~/repos/work/postgresql-operator main* ❯ k apply -f test-roles.yaml                                         15:22:15
role.postgresql.facets.cloud/test-role-with-override created
role.postgresql.facets.cloud/test-role-without-override created
~/repos/work/postgresql-operator main* ❯ k apply -f test-grantstatements.yaml                               15:23:48
grantstatement.postgresql.facets.cloud/grant-to-custom-user created
grantstatement.postgresql.facets.cloud/grant-to-normal-role created
~/repos/work/postgresql-operator main* ❯ kg roles.postgresql.facets.cloud                                   15:24:12
NAME                         STATUS   REASON        AGE
test-role-with-override      True     RoleCreated   39s
test-role-without-override   True     RoleCreated   39s
~/repos/work/postgresql-operator main* ❯ kg grantstatements.postgresql.facets.cloud                         15:24:27
NAME                   DATABASE   ROLE                         STATUS   REASON                   AGE
grant-to-custom-user   testdb     test-role-with-override      True     GrantStatementExecuted   42s
grant-to-normal-role   testdb     test-role-without-override   True     GrantStatementExecuted   42s
~/repos/work/postgresql-operator main* ❯ k delete grantstatements.postgresql.facets.cloud grant-to-custom-user grant-to-normal-role
grantstatement.postgresql.facets.cloud "grant-to-custom-user" deleted
grantstatement.postgresql.facets.cloud "grant-to-normal-role" deleted
~/repos/work/postgresql-operator main* ❯ k delete roles.postgresql.facets.cloud test-role-with-override test-role-without-override
role.postgresql.facets.cloud "test-role-with-override" deleted
role.postgresql.facets.cloud "test-role-without-override" deleted
```

- operator logs

```bash
root@dev-pod:/workspace/postgresql-operator# make run
test -s /workspace/postgresql-operator/bin/controller-gen && /workspace/postgresql-operator/bin/controller-gen --version | grep -q v0.11.1 || \
GOBIN=/workspace/postgresql-operator/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.11.1
/workspace/postgresql-operator/bin/controller-gen rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
/workspace/postgresql-operator/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
go fmt ./...
go vet ./...
go run ./main.go
2025-11-07T09:53:34Z    INFO    controller-runtime.metrics      Metrics server is starting to listen    {"addr": ":8080"}
2025-11-07T09:53:34Z    INFO    setup   starting manager
2025-11-07T09:53:34Z    INFO    Starting server {"kind": "health probe", "addr": "[::]:8081"}
2025-11-07T09:53:34Z    INFO    Starting server {"path": "/metrics", "kind": "metrics", "addr": "[::]:8080"}
2025-11-07T09:53:34Z    INFO    Starting EventSource    {"controller": "role", "controllerGroup": "postgresql.facets.cloud", "controllerKind": "Role", "source": "kind source: *v1alpha1.Role"}
2025-11-07T09:53:34Z    INFO    Starting EventSource    {"controller": "role", "controllerGroup": "postgresql.facets.cloud", "controllerKind": "Role", "source": "kind source: *v1.Secret"}
2025-11-07T09:53:34Z    INFO    Starting Controller     {"controller": "role", "controllerGroup": "postgresql.facets.cloud", "controllerKind": "Role"}
2025-11-07T09:53:34Z    INFO    Starting EventSource    {"controller": "grant", "controllerGroup": "postgresql.facets.cloud", "controllerKind": "Grant", "source": "kind source: *v1alpha1.Grant"}
2025-11-07T09:53:34Z    INFO    Starting Controller     {"controller": "grant", "controllerGroup": "postgresql.facets.cloud", "controllerKind": "Grant"}
2025-11-07T09:53:34Z    INFO    Starting EventSource    {"controller": "grantstatement", "controllerGroup": "postgresql.facets.cloud", "controllerKind": "GrantStatement", "source": "kind source: *v1alpha1.GrantStatement"}
2025-11-07T09:53:34Z    INFO    Starting Controller     {"controller": "grantstatement", "controllerGroup": "postgresql.facets.cloud", "controllerKind": "GrantStatement"}
2025-11-07T09:53:35Z    INFO    Starting workers        {"controller": "grantstatement", "controllerGroup": "postgresql.facets.cloud", "controllerKind": "GrantStatement", "worker count": 1}
2025-11-07T09:53:35Z    INFO    Starting workers        {"controller": "grant", "controllerGroup": "postgresql.facets.cloud", "controllerKind": "Grant", "worker count": 1}
2025-11-07T09:53:35Z    INFO    Starting workers        {"controller": "role", "controllerGroup": "postgresql.facets.cloud", "controllerKind": "Role", "worker count": 1}




2025-11-07T09:53:48Z    INFO    role_controller Role `custom_user_name` got created successfully
2025-11-07T09:53:48Z    INFO    role_controller Role `test-role-without-override` got created successfully
2025-11-07T09:54:12Z    INFO    controllers.GrantStatement      Successfully executed grant statements for GrantStatement grant-to-custom-user
2025-11-07T09:54:12Z    INFO    controllers.GrantStatement      Successfully executed grant statements for GrantStatement grant-to-normal-role






2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA "public" FROM "custom_user_name";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA "public" FROM "custom_user_name";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: REVOKE ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA "public" FROM "custom_user_name";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: REVOKE ALL ON SCHEMA "public" FROM "custom_user_name";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES IN SCHEMA "public" REVOKE ALL ON TABLES FROM "custom_user_name";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES IN SCHEMA "public" REVOKE ALL ON SEQUENCES FROM "custom_user_name";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES IN SCHEMA "public" REVOKE ALL ON FUNCTIONS FROM "custom_user_name";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA "public" REVOKE ALL ON TABLES FROM "custom_user_name";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA "public" REVOKE ALL ON SEQUENCES FROM "custom_user_name";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA "public" REVOKE ALL ON FUNCTIONS FROM "custom_user_name";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES IN SCHEMA "information_schema" REVOKE ALL ON TABLES FROM "custom_user_name";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES IN SCHEMA "information_schema" REVOKE ALL ON SEQUENCES FROM "custom_user_name";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES IN SCHEMA "information_schema" REVOKE ALL ON FUNCTIONS FROM "custom_user_name";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA "information_schema" REVOKE ALL ON TABLES FROM "custom_user_name";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA "information_schema" REVOKE ALL ON SEQUENCES FROM "custom_user_name";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA "information_schema" REVOKE ALL ON FUNCTIONS FROM "custom_user_name";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES IN SCHEMA "pg_catalog" REVOKE ALL ON TABLES FROM "custom_user_name";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES IN SCHEMA "pg_catalog" REVOKE ALL ON SEQUENCES FROM "custom_user_name";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES IN SCHEMA "pg_catalog" REVOKE ALL ON FUNCTIONS FROM "custom_user_name";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA "pg_catalog" REVOKE ALL ON TABLES FROM "custom_user_name";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA "pg_catalog" REVOKE ALL ON SEQUENCES FROM "custom_user_name";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA "pg_catalog" REVOKE ALL ON FUNCTIONS FROM "custom_user_name";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES IN SCHEMA "pg_toast" REVOKE ALL ON TABLES FROM "custom_user_name";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES IN SCHEMA "pg_toast" REVOKE ALL ON SEQUENCES FROM "custom_user_name";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES IN SCHEMA "pg_toast" REVOKE ALL ON FUNCTIONS FROM "custom_user_name";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA "pg_toast" REVOKE ALL ON TABLES FROM "custom_user_name";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA "pg_toast" REVOKE ALL ON SEQUENCES FROM "custom_user_name";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA "pg_toast" REVOKE ALL ON FUNCTIONS FROM "custom_user_name";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: REVOKE ALL PRIVILEGES ON DATABASE "testdb" FROM "custom_user_name"
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Successfully finalized GrantStatement grant-to-custom-user
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA "public" FROM "test-role-without-override";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA "public" FROM "test-role-without-override";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: REVOKE ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA "public" FROM "test-role-without-override";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: REVOKE ALL ON SCHEMA "public" FROM "test-role-without-override";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES IN SCHEMA "public" REVOKE ALL ON TABLES FROM "test-role-without-override";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES IN SCHEMA "public" REVOKE ALL ON SEQUENCES FROM "test-role-without-override";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES IN SCHEMA "public" REVOKE ALL ON FUNCTIONS FROM "test-role-without-override";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA "public" REVOKE ALL ON TABLES FROM "test-role-without-override";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA "public" REVOKE ALL ON SEQUENCES FROM "test-role-without-override";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA "public" REVOKE ALL ON FUNCTIONS FROM "test-role-without-override";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES IN SCHEMA "information_schema" REVOKE ALL ON TABLES FROM "test-role-without-override";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES IN SCHEMA "information_schema" REVOKE ALL ON SEQUENCES FROM "test-role-without-override";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES IN SCHEMA "information_schema" REVOKE ALL ON FUNCTIONS FROM "test-role-without-override";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA "information_schema" REVOKE ALL ON TABLES FROM "test-role-without-override";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA "information_schema" REVOKE ALL ON SEQUENCES FROM "test-role-without-override";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA "information_schema" REVOKE ALL ON FUNCTIONS FROM "test-role-without-override";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES IN SCHEMA "pg_catalog" REVOKE ALL ON TABLES FROM "test-role-without-override";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES IN SCHEMA "pg_catalog" REVOKE ALL ON SEQUENCES FROM "test-role-without-override";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES IN SCHEMA "pg_catalog" REVOKE ALL ON FUNCTIONS FROM "test-role-without-override";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA "pg_catalog" REVOKE ALL ON TABLES FROM "test-role-without-override";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA "pg_catalog" REVOKE ALL ON SEQUENCES FROM "test-role-without-override";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA "pg_catalog" REVOKE ALL ON FUNCTIONS FROM "test-role-without-override";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES IN SCHEMA "pg_toast" REVOKE ALL ON TABLES FROM "test-role-without-override";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES IN SCHEMA "pg_toast" REVOKE ALL ON SEQUENCES FROM "test-role-without-override";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES IN SCHEMA "pg_toast" REVOKE ALL ON FUNCTIONS FROM "test-role-without-override";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA "pg_toast" REVOKE ALL ON TABLES FROM "test-role-without-override";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA "pg_toast" REVOKE ALL ON SEQUENCES FROM "test-role-without-override";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA "pg_toast" REVOKE ALL ON FUNCTIONS FROM "test-role-without-override";
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Executing query: REVOKE ALL PRIVILEGES ON DATABASE "testdb" FROM "test-role-without-override"
2025-11-07T09:55:33Z    INFO    controllers.GrantStatement      Successfully finalized GrantStatement grant-to-normal-role




2025-11-07T09:56:13Z    INFO    role_controller Role `custom_user_name` got deleted successfully
2025-11-07T09:56:13Z    INFO    role_controller Role `test-role-without-override` got deleted successfully

```

- testing login

```bash
~/repos/work/postgresql-operator main* ❯ k exec -it psql-client -- bash                                      1m 5s 15:44:01
root@psql-client:/# PGPASSWORD=mynewrolepassword psql -U test-role-without-override -d testdb -h test-postgres-service 
psql (15.14 (Debian 15.14-1.pgdg13+1))
Type "help" for help.

testdb=> \d
Did not find any relations.
testdb=> \l
                                                         List of databases
   Name    |  Owner   | Encoding |  Collate   |   Ctype    | ICU Locale | Locale Provider |            Access privileges            
-----------+----------+----------+------------+------------+------------+-----------------+-----------------------------------------
 postgres  | postgres | UTF8     | en_US.utf8 | en_US.utf8 |            | libc            | 
 template0 | postgres | UTF8     | en_US.utf8 | en_US.utf8 |            | libc            | =c/postgres                            +
           |          |          |            |            |            |                 | postgres=CTc/postgres
 template1 | postgres | UTF8     | en_US.utf8 | en_US.utf8 |            | libc            | =c/postgres                            +
           |          |          |            |            |            |                 | postgres=CTc/postgres
 testdb    | postgres | UTF8     | en_US.utf8 | en_US.utf8 |            | libc            | =Tc/postgres                           +
           |          |          |            |            |            |                 | postgres=CTc/postgres                  +
           |          |          |            |            |            |                 | custom_user_name=c/postgres            +
           |          |          |            |            |            |                 | "test-role-without-override"=c/postgres
(4 rows)

testdb=> exit
root@psql-client:/# PGPASSWORD=mynewrolepassword psql -U custom_user_name -d testdb -h test-postgres-service 
psql (15.14 (Debian 15.14-1.pgdg13+1))
Type "help" for help.

testdb=> \d
Did not find any relations.
testdb=> \l
                                                         List of databases
   Name    |  Owner   | Encoding |  Collate   |   Ctype    | ICU Locale | Locale Provider |            Access privileges            
-----------+----------+----------+------------+------------+------------+-----------------+-----------------------------------------
 postgres  | postgres | UTF8     | en_US.utf8 | en_US.utf8 |            | libc            | 
 template0 | postgres | UTF8     | en_US.utf8 | en_US.utf8 |            | libc            | =c/postgres                            +
           |          |          |            |            |            |                 | postgres=CTc/postgres
 template1 | postgres | UTF8     | en_US.utf8 | en_US.utf8 |            | libc            | =c/postgres                            +
           |          |          |            |            |            |                 | postgres=CTc/postgres
 testdb    | postgres | UTF8     | en_US.utf8 | en_US.utf8 |            | libc            | =Tc/postgres                           +
           |          |          |            |            |            |                 | postgres=CTc/postgres                  +
           |          |          |            |            |            |                 | custom_user_name=c/postgres            +
           |          |          |            |            |            |                 | "test-role-without-override"=c/postgres
(4 rows)

testdb=> exit
root@psql-client:/# exit
exit
```



## Testing for user `_`

- secret 
```yaml
apiVersion: v1
kind: Secret
metadata:
  name: db-conn
  namespace: default
type: Opaque
stringData:
  endpoint: "test-postgres-service"
  port: "5432"
  database: "testdb"
  username: "postgres"
  password: "password"
  sslmode: "disable"
  role_password: "mynewrolepassword"

```
- role
```yaml
apiVersion: postgresql.facets.cloud/v1alpha1
kind: Role
metadata:
  name: test-role-with-override
  namespace: default
spec:
  connectSecretRef:
    name: db-conn
    namespace: default
  passwordSecretRef:
    namespace: default
    name: db-conn
    key: role_password
  userNameOverride: "_"
  connectionLimit: 50
  privileges:
    login: true
    createDb: true
    inherit: false
    superUser: false
    createRole: false
    replication: false
    bypassRls: false
    
 ```
 
 - grantstatement
 ```yaml
 apiVersion: postgresql.facets.cloud/v1alpha1
kind: GrantStatement
metadata:
  name: grant-to-custom-user
  namespace: default
spec:
  roleRef:
    name: test-role-with-override
    namespace: default
  database: "testdb"
  statements:
  - 'GRANT CONNECT ON DATABASE testdb TO "_";'
  - 'GRANT USAGE ON SCHEMA public TO "_";'
  - 'GRANT SELECT, INSERT, UPDATE ON ALL TABLES IN SCHEMA public TO "_";'
 
 ```
 
 - commands and login test
 ```bash
 ~/repos/work/postgresql-operator support-username-override* ❯ k apply -f test-roles.yaml                    16:06:08
role.postgresql.facets.cloud/test-role-with-override created
~/repos/work/postgresql-operator support-username-override* ❯ k apply -f test-grantstatements.yaml          16:06:16
grantstatement.postgresql.facets.cloud/grant-to-custom-user created
~/repos/work/postgresql-operator support-username-override* ❯ k exec -it psql-client -- bash                16:06:31
root@psql-client:/# PGPASSWORD=mynewrolepassword psql -U _ -d testdb -h test-postgres-service 
psql (15.14 (Debian 15.14-1.pgdg13+1))
Type "help" for help.

testdb=> \d
Did not find any relations.
testdb=> \l
                                                List of databases
   Name    |  Owner   | Encoding |  Collate   |   Ctype    | ICU Locale | Locale Provider |   Access privileges   
-----------+----------+----------+------------+------------+------------+-----------------+-----------------------
 postgres  | postgres | UTF8     | en_US.utf8 | en_US.utf8 |            | libc            | 
 template0 | postgres | UTF8     | en_US.utf8 | en_US.utf8 |            | libc            | =c/postgres          +
           |          |          |            |            |            |                 | postgres=CTc/postgres
 template1 | postgres | UTF8     | en_US.utf8 | en_US.utf8 |            | libc            | =c/postgres          +
           |          |          |            |            |            |                 | postgres=CTc/postgres
 testdb    | postgres | UTF8     | en_US.utf8 | en_US.utf8 |            | libc            | =Tc/postgres         +
           |          |          |            |            |            |                 | postgres=CTc/postgres+
           |          |          |            |            |            |                 | _=c/postgres
(4 rows)

testdb=> exit
root@psql-client:/# exit
exit
~/repos/work/postgresql-operator support-username-override* ❯ k delete -f test-grantstatements.yaml     26s 16:07:23
grantstatement.postgresql.facets.cloud "grant-to-custom-user" deleted
~/repos/work/postgresql-operator support-username-override* ❯ k delete -f test-roles.yaml                   16:10:50
role.postgresql.facets.cloud "test-role-with-override" deleted
```

- operator logs
```bash




2025-11-07T10:36:16Z    INFO    role_controller Role `_` got created successfully
2025-11-07T10:36:31Z    INFO    controllers.GrantStatement      Successfully executed grant statements for GrantStatement grant-to-custom-user
2025-11-07T10:40:50Z    INFO    controllers.GrantStatement      Executing query: REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA "public" FROM "_";
2025-11-07T10:40:50Z    INFO    controllers.GrantStatement      Executing query: REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA "public" FROM "_";
2025-11-07T10:40:50Z    INFO    controllers.GrantStatement      Executing query: REVOKE ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA "public" FROM "_";
2025-11-07T10:40:50Z    INFO    controllers.GrantStatement      Executing query: REVOKE ALL ON SCHEMA "public" FROM "_";
2025-11-07T10:40:50Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES IN SCHEMA "public" REVOKE ALL ON TABLES FROM "_";
2025-11-07T10:40:50Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES IN SCHEMA "public" REVOKE ALL ON SEQUENCES FROM "_";
2025-11-07T10:40:50Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES IN SCHEMA "public" REVOKE ALL ON FUNCTIONS FROM "_";
2025-11-07T10:40:50Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA "public" REVOKE ALL ON TABLES FROM "_";
2025-11-07T10:40:50Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA "public" REVOKE ALL ON SEQUENCES FROM "_";
2025-11-07T10:40:50Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA "public" REVOKE ALL ON FUNCTIONS FROM "_";
2025-11-07T10:40:50Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES IN SCHEMA "information_schema" REVOKE ALL ON TABLES FROM "_";
2025-11-07T10:40:50Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES IN SCHEMA "information_schema" REVOKE ALL ON SEQUENCES FROM "_";
2025-11-07T10:40:50Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES IN SCHEMA "information_schema" REVOKE ALL ON FUNCTIONS FROM "_";
2025-11-07T10:40:50Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA "information_schema" REVOKE ALL ON TABLES FROM "_";
2025-11-07T10:40:50Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA "information_schema" REVOKE ALL ON SEQUENCES FROM "_";
2025-11-07T10:40:50Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA "information_schema" REVOKE ALL ON FUNCTIONS FROM "_";
2025-11-07T10:40:50Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES IN SCHEMA "pg_catalog" REVOKE ALL ON TABLES FROM "_";
2025-11-07T10:40:50Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES IN SCHEMA "pg_catalog" REVOKE ALL ON SEQUENCES FROM "_";
2025-11-07T10:40:50Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES IN SCHEMA "pg_catalog" REVOKE ALL ON FUNCTIONS FROM "_";
2025-11-07T10:40:50Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA "pg_catalog" REVOKE ALL ON TABLES FROM "_";
2025-11-07T10:40:50Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA "pg_catalog" REVOKE ALL ON SEQUENCES FROM "_";
2025-11-07T10:40:50Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA "pg_catalog" REVOKE ALL ON FUNCTIONS FROM "_";
2025-11-07T10:40:50Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES IN SCHEMA "pg_toast" REVOKE ALL ON TABLES FROM "_";
2025-11-07T10:40:50Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES IN SCHEMA "pg_toast" REVOKE ALL ON SEQUENCES FROM "_";
2025-11-07T10:40:50Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES IN SCHEMA "pg_toast" REVOKE ALL ON FUNCTIONS FROM "_";
2025-11-07T10:40:50Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA "pg_toast" REVOKE ALL ON TABLES FROM "_";
2025-11-07T10:40:50Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA "pg_toast" REVOKE ALL ON SEQUENCES FROM "_";
2025-11-07T10:40:50Z    INFO    controllers.GrantStatement      Executing query: ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA "pg_toast" REVOKE ALL ON FUNCTIONS FROM "_";
2025-11-07T10:40:50Z    INFO    controllers.GrantStatement      Executing query: REVOKE ALL PRIVILEGES ON DATABASE "testdb" FROM "_"
2025-11-07T10:40:50Z    INFO    controllers.GrantStatement      Successfully finalized GrantStatement grant-to-custom-user
2025-11-07T10:41:04Z    INFO    role_controller Role `_` got deleted successfully

```