### PR TITLE
ISR-11280 Fix unbounded Role status.conditions growth and GrantStatement REVOKE-without-regrant bug

### DIFF
--- a/controllers/postgresql/grantstatement_controller.go
+++ b/controllers/postgresql/grantstatement_controller.go
@@ -63,6 +63,13 @@ var (
 type GrantStatementReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
+	// APIReader bypasses the manager's cache. The skip-if-unchanged check below
+	// must never evaluate against a status the cache hasn't caught up on yet -
+	// otherwise a reconcile that just ran REVOKE ALL can be immediately followed
+	// by another reconcile that reads the pre-revoke cached status, wrongly
+	// concludes nothing changed, and skips re-granting, leaving the role with
+	// no privileges. Reading the object live here closes that race.
+	APIReader client.Reader
 }
 
 //+kubebuilder:rbac:groups=postgresql.facets.cloud,resources=grantstatements,verbs=get;list;watch;create;update;patch;delete
@@ -84,9 +91,14 @@ func (r *GrantStatementReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		panic(err)
 	}
 
-	// get grantstatement resource
+	// get grantstatement resource - read live (not from the cache) since the
+	// skip-if-unchanged decision below depends on this object's latest status
+	reader := r.APIReader
+	if reader == nil {
+		reader = r.Client
+	}
 	grantStatement := &postgresqlv1alpha1.GrantStatement{}
-	err = r.Get(ctx, req.NamespacedName, grantStatement)
+	err = reader.Get(ctx, req.NamespacedName, grantStatement)
 	if err != nil {
 		return ctrl.Result{}, nil
 	}

--- a/controllers/postgresql/role_controller.go
+++ b/controllers/postgresql/role_controller.go
@@ -481,7 +481,7 @@ func (r *RoleReconciler) appendRoleStatusCondition(ctx context.Context, role *po
 
 		getLastItem := roleStatusConditions[len(roleStatusConditions)-1]
 		if getLastItem.Reason != condition.Reason {
-			role.Status.Conditions = append(role.Status.Conditions, condition)
+			role.Status.Conditions = append(roleStatusConditions, condition)
 			err := r.Status().Update(ctx, role)
 			if err != nil {
 				roleLogger.Error(err, fmt.Sprintf("Resource status update failed for role `%s`", role.Name))

--- a/main.go
+++ b/main.go
@@ -106,8 +106,9 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&postgresqlcontrollers.GrantStatementReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:    mgr.GetClient(),
+		Scheme:    mgr.GetScheme(),
+		APIReader: mgr.GetAPIReader(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "GrantStatement")
 		os.Exit(1)


### PR DESCRIPTION
## Summary

Two related reliability bugs found and fixed during a production incident investigation on 21-22 July 2026:

### 1. `RoleReconciler` - unbounded `status.conditions` growth
- `appendRoleStatusCondition` in `role_controller.go` computes a trimmed slice (last 5 conditions) into a local variable, but then appends the new condition onto the original, untrimmed `role.Status.Conditions` field - silently discarding the trim on every call.
- In production, this let a single `Role` object accumulate **8,000+ conditions (900KB+)**, exceeding etcd's request size limit. Every subsequent status write then failed with `etcdserver: request is too large`, and the resulting error-driven requeue caused the object to grow even faster - a self-reinforcing loop that never recovers on its own.
- The sibling reconcilers (`GrantReconciler.appendGrantStatusCondition`, `GrantStatementReconciler.appendGrantStatementStatusCondition`) already implement this trim correctly - this PR brings `RoleReconciler` in line with that existing, correct pattern.

### 2. `GrantStatementReconciler` - skips re-GRANT after REVOKE ALL on a stale cache read
- The reconciler's skip-if-unchanged check (`isLastConditionSuccess(...) && !hasGrantStatementChanged(...)`) was evaluated against the manager's cached client.
- Once issue #1 above was fixed and several long-stuck `Role`/`GrantStatement` objects finally became reconcilable again, a reconcile that had just executed `REVOKE ALL` could be immediately followed by another reconcile reading the **pre-revoke cached status**, which incorrectly concluded nothing had changed and skipped re-applying the declared `GRANT` statements - leaving the role with **zero privileges** until the `GrantStatement`'s spec changed again.
- Root-caused during a production incident: `canvas-server-user` lost all privileges on `common_auth` after its `GrantStatement` controller reconciled for the first time in months (once a stuck connectivity issue was resolved), hitting exactly this REVOKE-then-skip sequence. The application failed with `permission denied for table instances` as a direct result.

## Fix
1. One-line change in `appendRoleStatusCondition`: append onto the already-trimmed `roleStatusConditions` local variable instead of the untrimmed `role.Status.Conditions` field.
2. `GrantStatementReconciler` now reads the `GrantStatement` object live via the manager's `APIReader` (bypassing the cache) before making the skip decision, so the skip check always reflects the latest status rather than a potentially stale, pre-revoke cached copy.

## Test plan
- [x] Confirmed via `kubectl get roles.postgresql.facets.cloud -A` in a live cluster that multiple `Role` objects had condition counts in the 8,000-8,900 range and object sizes near 1MB.
- [x] Manually truncated `.status.conditions` on the affected objects (via a direct PATCH to the `/status` subresource) to unblock reconciliation immediately.
- [x] Reproduced the REVOKE-without-regrant sequence directly in production operator logs (`REVOKE ALL ...` immediately followed by `"already been successfully executed, skipping execution"` for the same object) before applying the fix.
- [x] Verified both changes are type-safe (no local Go toolchain was available to run `go build`, but `client.Reader`/`client.Client` and the `[]metav1.Condition` swap cannot introduce a compile error).
- [ ] Recommend adding a unit test asserting `len(role.Status.Conditions) <= 6` after repeated calls to `appendRoleStatusCondition` with alternating reasons.
- [ ] Recommend adding an envtest-based integration test for `GrantStatementReconciler.Reconcile` that exercises the REVOKE-then-reconcile-again sequence against a stale cache, once test scaffolding (flag registration, fake DB) exists for this controller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
